### PR TITLE
Check for empty values in $args

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class gor (
   $service_ensure = running,
 ) {
   validate_hash($args)
-  if empty($args) {
+  if empty($args) or empty(values($args)) {
     fail("${title}: args param is empty")
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -61,5 +61,21 @@ describe 'gor' do
         expect { should }.to raise_error(Puppet::Error, /args param is empty/)
       end
     end
+
+    context 'hash with empty values' do
+      let(:params) {{
+        :args => {
+          '-input-raw'          => ':80',
+          '-output-http'        => '',
+          '-output-http-method' => [
+            'GET', 'HEAD', 'OPTIONS'
+          ],
+        },
+      }}
+
+      it do
+        expect { should }.to raise_error(Puppet::Error, /args param is empty/)
+      end
+    end
   end
 end


### PR DESCRIPTION
We have seen issues where $args may have empty
values causing init scripts to get written without
a needed arg and Gor doesn’t start. In this case,
barf early and don’t write an empty init config.

Example:

```
description "Gor traffic replay"

start on runlevel [2345]
stop on runlevel [!2345]

respawn
respawn limit 5 20

exec /usr/bin/gor \
  -input-raw='localhost:7999' \
  -output-http='' \
  -output-http-method='GET' \
  -output-http-method='HEAD' \
  -output-http-method='OPTIONS'
```