### PR TITLE
Force containerised builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 # Verify this with: http://lint.travis-ci.org/
 language: ruby
+# Force containerised builds
+sudo: false
 # Delete dependency locks for matrix builds.
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test


### PR DESCRIPTION
Containerised builds are faster and cheaper to run for Travis. There's no
reason we shouldn't use them, and we do across existing projects already.