### PR TITLE
Fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
 
 gem 'rake', '~> 10.1.0'
 gem 'puppet-lint'
-gem 'rspec-puppet'
+gem 'rspec-puppet', '~> 2.2.0'
 gem 'rspec-system-puppet'
 gem 'puppetlabs_spec_helper'
 gem 'puppet-syntax'

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -48,7 +48,7 @@ describe 'gor' do
       }}
 
       it do
-        expect { is_expected.to }.to raise_error(Puppet::Error, /is not a Hash/)
+        is_expected.to raise_error(Puppet::Error, /is not a Hash/)
       end
     end
 
@@ -58,7 +58,7 @@ describe 'gor' do
       }}
 
       it do
-        expect { is_expected.to }.to raise_error(Puppet::Error, /args param is empty/)
+        is_expected.to raise_error(Puppet::Error, /args param is empty/)
       end
     end
   end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -14,7 +14,7 @@ describe 'gor' do
       }}
 
       it 'should configure gor with the correct arguments' do
-        should contain_file(upstart_file).with_content(/^exec \/usr\/bin\/gor \\
+        is_expected.to contain_file(upstart_file).with_content(/^exec \/usr\/bin\/gor \\
   -input-raw=':80' \\
   -output-http='http:\/\/staging' \\
   -output-http-header='User-Agent: gor'$/)
@@ -33,7 +33,7 @@ describe 'gor' do
       }}
 
       it 'should configure gor with the correct arguments' do
-        should contain_file(upstart_file).with_content(/^exec \/usr\/bin\/gor \\
+        is_expected.to contain_file(upstart_file).with_content(/^exec \/usr\/bin\/gor \\
   -input-raw=':80' \\
   -output-http='http:\/\/staging' \\
   -output-http-method='GET' \\
@@ -48,7 +48,7 @@ describe 'gor' do
       }}
 
       it do
-        expect { should }.to raise_error(Puppet::Error, /is not a Hash/)
+        expect { is_expected.to }.to raise_error(Puppet::Error, /is not a Hash/)
       end
     end
 
@@ -58,7 +58,7 @@ describe 'gor' do
       }}
 
       it do
-        expect { should }.to raise_error(Puppet::Error, /args param is empty/)
+        expect { is_expected.to }.to raise_error(Puppet::Error, /args param is empty/)
       end
     end
   end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -7,7 +7,7 @@ describe 'gor' do
         :args => { '--foo' => 'bar' },
       }}
 
-      it { should contain_package('gor').with_ensure('present') }
+      it { is_expected.to contain_package('gor').with_ensure('present') }
     end
 
     context '1.2.3' do
@@ -16,7 +16,7 @@ describe 'gor' do
         :package_ensure => '1.2.3',
       }}
 
-      it { should contain_package('gor').with_ensure('1.2.3') }
+      it { is_expected.to contain_package('gor').with_ensure('1.2.3') }
     end
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -8,7 +8,7 @@ describe 'gor' do
       }}
 
       it {
-        should contain_service('gor').with(
+        is_expected.to contain_service('gor').with(
           :ensure     => 'running',
           :enable     => 'true',
           :hasrestart => 'false'
@@ -23,7 +23,7 @@ describe 'gor' do
       }}
 
       it {
-        should contain_service('gor').with(
+        is_expected.to contain_service('gor').with(
           :ensure     => 'stopped',
           :enable     => 'false',
           :hasrestart => 'false'

--- a/spec/system/basic_spec.rb
+++ b/spec/system/basic_spec.rb
@@ -7,9 +7,9 @@ describe 'basic tests' do
     EOS
 
     puppet_apply(pp) do |r|
-      r.exit_code.should == 2
+      expect(r.exit_code).to eq(2)
       r.refresh
-      r.exit_code.should be_zero
+      expect(r.exit_code).to be_zero
     end
   end
 end


### PR DESCRIPTION
`puppet-rspec` isn't pinned to a version, so we pick up the latest from Rubygems at build time. This, in turn, dictates the version of RSpec we use, which in this case, becomes 2.99.0. This version uses a different syntax around `expect`. Use Transpec to pick up a lot of them, and then make a few manual changes to fix the rest.