### PR TITLE
Update Travis test fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ language: ruby
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
-  - 1.8.7
   - 1.9.3
 env:
   matrix:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.3.0"
+  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.5.0"
+  - PUPPET_VERSION="~> 3.6.0"
 # Only notify for failed builds.
 notifications:
   email:


### PR DESCRIPTION
Deprecate Ruby 1.8.7 and Puppet 2.7.0 since we no longer support them. Add
fixtures to test versions of Puppet which more closely match those we use in
production.