### PR TITLE
Add options to Gor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2016-07-15 Release 0.3.1
+- Support ability to pass in environment variables
+- Support explicitly setting binary path 
+
 2016-07-12 Release 0.3.0
 - Support command-line options which don't have values
 - Support Puppet 3.8

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,8 @@ exclude_paths = [
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 
+task :default => [:test]
+
 desc "Run syntax, lint, and spec tests."
 task :test => [
   :syntax,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,8 @@
 #
 class gor::config {
   $args = $::gor::args
+  $envvars = $::gor::envvars
+  $binary_path = $::gor::binary_path
 
   file { '/etc/init/gor.conf':
     content => template('gor/etc/init/gor.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,15 +15,26 @@
 #   Ensure parameter to pass to the service.
 #   Default: running
 #
+# [*envvars*]
+#   Environment variables to be passed into the upstart config. This could
+#   be used to turn on debugging options.
+#
+# [*binary_path*]
+#   Specify the location of the Gor binary.
+#
 class gor (
   $args,
   $package_ensure = present,
   $service_ensure = running,
+  $envvars = {},
+  $binary_path = '/usr/bin/gor',
 ) {
   validate_hash($args)
   if empty($args) {
     fail("${title}: args param is empty")
   }
+
+  validate_hash($envvars)
 
   anchor { 'gor::begin': } ->
   class { 'gor::package': } ->

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-gor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Government Digital Service",
   "license": "MIT",
   "summary": "Module to manage gor",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -79,4 +79,38 @@ describe 'gor' do
       end
     end
   end
+
+  describe '#envvars' do
+    context 'valid hash' do
+      let(:params) {{
+        :envvars => {
+          'GODEBUG' => 'netdns=go',
+          'FOO'     => 'bar',
+        },
+        :args => {
+          '-output-http-header' => 'User-Agent: gor',
+          '-output-http'        => 'http://staging',
+          '-input-raw'          => ':80',
+        },
+      }}
+
+      it 'should configure gor with correct environment variables in place' do
+        is_expected.to contain_file(upstart_file).with_content(/^env GODEBUG=\'netdns=go\'\nenv FOO=\'bar\'$/)
+      end
+    end
+    context 'empty hash' do
+      let(:params) {{
+        :envvars => {},
+        :args => {
+          '-output-http-header' => 'User-Agent: gor',
+          '-output-http'        => 'http://staging',
+          '-input-raw'          => ':80',
+        },
+      }}
+
+      it 'should configure gor without setting environment variables' do
+        is_expected.not_to contain_file(upstart_file).with_content(/^env GODEBUG=\'netdns=go\'\nenv FOO=\'bar\'$/)
+      end
+    end
+  end
 end

--- a/templates/etc/init/gor.conf.erb
+++ b/templates/etc/init/gor.conf.erb
@@ -6,7 +6,11 @@ stop on runlevel [!2345]
 respawn
 respawn limit 5 20
 
-exec /usr/bin/gor \
+<%  @envvars.each do |k, v| %>
+<%=   "env #{k}='#{v}'" -%>
+<%  end %>
+
+exec <%= @binary_path %> \
   <%=
 @args.sort.map { |k,v|
   [v].flatten.map { |i|


### PR DESCRIPTION
This commit adds the ability to set a different binary path than the
default, as we found in upgrading that the path was set to
/usr/loca/bin/gor rather than /usr/bin/gor so the service failed to
start.

It also allows adding a hash on environment variables which will be
loaded into the upstart file and loaded when the service starts. This is
due to a bug that we ran into in updating documented here:
https://github.com/buger/gor/wiki/Troubleshooting#gor-is-crashing-with-following-stacktrace