### PR TITLE
Add configurable package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@
 #
 class gor (
   $args,
+  $package_name = 'gor',
   $package_ensure = present,
   $service_ensure = running,
   $envvars = {},

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -3,9 +3,10 @@
 # Private class. Should not be called directly.
 #
 class gor::package {
+  $package_name = $::gor::package_name
   $package_ensure = $::gor::package_ensure
 
-  package { 'gor':
+  package { $package_name:
     ensure => $package_ensure,
   }
 }


### PR DESCRIPTION
This commit adds a configurable package name, which defaults to `gor`. This allow newer versions, now named `goreplay` to be used alongside older versions.